### PR TITLE
Add printing BLE device address to serial monitor

### DIFF
--- a/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
+++ b/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
@@ -62,6 +62,10 @@ void setup()
   BLE.addService(audioService);
   BLE.advertise();
 
+  // Print device address
+  Serial.print("Device Address: ");
+  Serial.println(BLE.address());
+    
   Serial.println("BLE Audio Recorder");
 }
 


### PR DESCRIPTION
Adds the device ble address to the serial monitor so that you instantly know what it is.