### PR TITLE
Fixes boot

### DIFF
--- a/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
+++ b/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
@@ -31,6 +31,12 @@ void setup()
   pinMode(LED_BLUE, OUTPUT);
   pinMode(LED_GREEN, OUTPUT);
   Serial.begin(115200);
+  
+  unsigned long startMillis = millis();
+  while (!Serial && millis() - startMillis < 500)
+  {
+    delay(10); // Short delay to prevent hanging in a tight loop
+  }
 
 #if defined(WIO_TERMINAL)
   pinMode(WIO_KEY_A, INPUT_PULLUP);

--- a/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
+++ b/src/BluetoothDeviceDriver/BluetoothDeviceDriver.ino
@@ -31,10 +31,6 @@ void setup()
   pinMode(LED_BLUE, OUTPUT);
   pinMode(LED_GREEN, OUTPUT);
   Serial.begin(115200);
-  while (!Serial)
-  {
-    delay(10);
-  }
 
 #if defined(WIO_TERMINAL)
   pinMode(WIO_KEY_A, INPUT_PULLUP);


### PR DESCRIPTION
this bit of code was preventing boot as it was waiting for serial, by removing it the device is now able to properly boot!

```
while (!Serial)
{
  delay(10);
}
```
things to note: removing this loop means we won't see the startup logs unless we directly restart it while its connected to serial

# Update

added a 500ms wait to check if there is serial, if so connect to that if not start as normal

```
  unsigned long startMillis = millis();
  while (!Serial && millis() - startMillis < 500)
  {
    delay(10); // Short delay to prevent hanging in a tight loop
  }
```