### PR TITLE
[build] remove supabase env vars

### DIFF
--- a/apps/AppStandalone/lib/env/env.dart
+++ b/apps/AppStandalone/lib/env/env.dart
@@ -26,10 +26,4 @@ abstract class Env {
   static const String firebaseAppId = _Env.firebaseAppId;
   @EnviedField(varName: 'FIREBASE_MEASUREMENT_ID')
   static const String firebaseMeasurementId = _Env.firebaseMeasurementId;
-
-  // Supabase
-  @EnviedField(varName: 'SUPABASE_URL')
-  static const String supabaseUrl = _Env.supabaseUrl;
-  @EnviedField(varName: 'SUPABASE_ANON_KEY')
-  static const String supabaseAnonKey = _Env.supabaseAnonKey;
 }


### PR DESCRIPTION
According to https://discordapp.com/channels/1192313062041067520/1226079093859287051/1231048604852949052 and https://github.com/BasedHardware/Friend/pull/58 we don't use supabase anymore for the standalone app. Remove the env vars so that `dart run build_runner build` works again to generate env vars at build time.