### PR TITLE
docs: Add dark theme and ability to switch between light

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,7 @@ theme: just-the-docs
 url: https://basedhardware.github.io
 logo: "/images/logo.png"
 favicon_ico: "/images/favicon.ico"
+color_scheme: dark
 
 collections:
   get_started:

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,15 @@
+<button class="btn js-toggle-dark-mode">☼</button>
+
+<script>
+  const toggleDarkMode = document.querySelector(".js-toggle-dark-mode");
+
+  jtd.addEvent(toggleDarkMode, "click", function () {
+    if (jtd.getTheme() === "light") {
+      jtd.setTheme("dark");
+      toggleDarkMode.textContent = "☼";
+    } else {
+      jtd.setTheme("light");
+      toggleDarkMode.textContent = "☾";
+    }
+  });
+</script>


### PR DESCRIPTION
Added toggling between themes and set dark by default. 

**Note:** In dark mode logo logs a bit off. Not sure where it was created, but we could add a white outline to the text or just have an alt white text version of a logo.