### PR TITLE
Removed "Created with https://www.aisama.co/'," from shared memories

### DIFF
--- a/apps/AppWithWearable/lib/pages/memories/widgets/memory_operations.dart
+++ b/apps/AppWithWearable/lib/pages/memories/widgets/memory_operations.dart
@@ -38,7 +38,7 @@ geyShareMemoryOperationWidget(MemoryRecord memory, {double iconSize = 20}) {
       highlightColor: Colors.transparent,
       onTap: () async {
         await Share.share(
-          '${memory.structuredMemory}  Created with https://www.aisama.co/',
+          '${memory.structuredMemory}',
           sharePositionOrigin: getWidgetBoundingBox(context),
         );
         HapticFeedback.lightImpact();


### PR DESCRIPTION
Removed "Created with https://www.aisama.co/'," from shared memories

when i shared a memory from the app to another app it added "Created with https://www.aisama.co/'," at the end, this is not needed