### PR TITLE
Obfuscate API Keys

### DIFF
--- a/apps/AppStandalone/lib/env/env.dart
+++ b/apps/AppStandalone/lib/env/env.dart
@@ -1,7 +1,7 @@
 import 'package:envied/envied.dart';
 part 'env.g.dart';
 
-@Envied(path: '.env')
+@Envied(path: '.env', obfuscate: true)
 abstract class Env {
   // OpenAI
   @EnviedField(varName: 'OPENAI_API_KEY')


### PR DESCRIPTION
By default, obfuscation is not enabled in the envied package, this will make it hard to reverse-engineer encrypted API keys https://github.com/petercinibulk/envied/pull/4 

Read more here
https://pub.dev/packages/envied#obfuscationencryption