### PR TITLE
feat: notification action routing

### DIFF
--- a/apps/AppWithWearable/lib/backend/preferences.dart
+++ b/apps/AppWithWearable/lib/backend/preferences.dart
@@ -224,6 +224,8 @@ class SharedPreferencesUtil {
   int get pageToShowFromNotification => getInt('pageToShowFromNotification') ?? 1;
 }
 
-String getOpenAIApiKeyForUsage() => SharedPreferencesUtil().openAIApiKey.isEmpty ? Env.openAIAPIKey! : SharedPreferencesUtil().openAIApiKey;
+String getOpenAIApiKeyForUsage() =>
+    SharedPreferencesUtil().openAIApiKey.isEmpty ? Env.openAIAPIKey! : SharedPreferencesUtil().openAIApiKey;
 
-String getDeepgramApiKeyForUsage() => SharedPreferencesUtil().deepgramApiKey.isEmpty ? Env.deepgramApiKey! : SharedPreferencesUtil().deepgramApiKey;
+String getDeepgramApiKeyForUsage() =>
+    SharedPreferencesUtil().deepgramApiKey.isEmpty ? Env.deepgramApiKey! : SharedPreferencesUtil().deepgramApiKey;

--- a/apps/AppWithWearable/lib/backend/preferences.dart
+++ b/apps/AppWithWearable/lib/backend/preferences.dart
@@ -222,6 +222,9 @@ class SharedPreferencesUtil {
   bool get scriptMemoriesToObjectBoxExecuted => getBool('scriptMemoriesToObjectBoxExecuted') ?? false;
   set pageToShowFromNotification(int value) => saveInt('pageToShowFromNotification', value);
   int get pageToShowFromNotification => getInt('pageToShowFromNotification') ?? 1;
+
+  set subPageToShowFromNotification(String value) => saveString('subPageToShowFromNotification', value);
+  String get subPageToShowFromNotification => getString('subPageToShowFromNotification') ?? '';
 }
 
 String getOpenAIApiKeyForUsage() =>

--- a/apps/AppWithWearable/lib/backend/preferences.dart
+++ b/apps/AppWithWearable/lib/backend/preferences.dart
@@ -220,10 +220,10 @@ class SharedPreferencesUtil {
   set scriptMemoriesToObjectBoxExecuted(bool value) => saveBool('scriptMemoriesToObjectBoxExecuted', value);
 
   bool get scriptMemoriesToObjectBoxExecuted => getBool('scriptMemoriesToObjectBoxExecuted') ?? false;
+  set pageToShowFromNotification(int value) => saveInt('pageToShowFromNotification', value);
+  int get pageToShowFromNotification => getInt('pageToShowFromNotification') ?? 1;
 }
 
-String getOpenAIApiKeyForUsage() =>
-    SharedPreferencesUtil().openAIApiKey.isEmpty ? Env.openAIAPIKey! : SharedPreferencesUtil().openAIApiKey;
+String getOpenAIApiKeyForUsage() => SharedPreferencesUtil().openAIApiKey.isEmpty ? Env.openAIAPIKey! : SharedPreferencesUtil().openAIApiKey;
 
-String getDeepgramApiKeyForUsage() =>
-    SharedPreferencesUtil().deepgramApiKey.isEmpty ? Env.deepgramApiKey! : SharedPreferencesUtil().deepgramApiKey;
+String getDeepgramApiKeyForUsage() => SharedPreferencesUtil().deepgramApiKey.isEmpty ? Env.deepgramApiKey! : SharedPreferencesUtil().deepgramApiKey;

--- a/apps/AppWithWearable/lib/main.dart
+++ b/apps/AppWithWearable/lib/main.dart
@@ -59,15 +59,25 @@ class MyApp extends StatefulWidget {
   State<MyApp> createState() => _MyAppState();
 
   static _MyAppState of(BuildContext context) => context.findAncestorStateOfType<_MyAppState>()!;
+  // The navigator key is necessary to navigate using static methods
+  static final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 }
 
 class _MyAppState extends State<MyApp> {
+  @override
+  void initState() {
+    NotificationUtil.initializeNotificationsEventListeners();
+    NotificationUtil.initializeIsolateReceivePort();
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       navigatorObservers: [InstabugNavigatorObserver()],
       debugShowCheckedModeBanner: F.env == Environment.dev,
       title: F.title,
+      navigatorKey: MyApp.navigatorKey,
       localizationsDelegates: const [
         GlobalMaterialLocalizations.delegate,
         GlobalWidgetsLocalizations.delegate,

--- a/apps/AppWithWearable/lib/pages/home/page.dart
+++ b/apps/AppWithWearable/lib/pages/home/page.dart
@@ -131,6 +131,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
       body: 'Check out your daily summary to see what you should do tomorrow.',
       notificationId: 5,
       isDailySummaryNotification: true,
+      payload: {'path': '/chat'},
     );
 
     super.initState();
@@ -147,7 +148,8 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
           });
           InstabugLog.logInfo('Friend Device Disconnected');
           if (SharedPreferencesUtil().reconnectNotificationIsChecked) {
-            createNotification(title: 'Friend Device Disconnected', body: 'Please reconnect to continue using your Friend.');
+            createNotification(
+                title: 'Friend Device Disconnected', body: 'Please reconnect to continue using your Friend.');
           }
           MixpanelManager().deviceDisconnected();
           foregroundUtil.stopForegroundTask();
@@ -205,6 +207,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
           onTap: () {
             FocusScope.of(context).unfocus();
             chatTextFieldFocusNode.unfocus();
+
             memoriesTextFieldFocusNode.unfocus();
           },
           child: Stack(
@@ -244,8 +247,12 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                       color: Colors.black,
                       borderRadius: BorderRadius.all(Radius.circular(16)),
                       border: GradientBoxBorder(
-                        gradient:
-                            LinearGradient(colors: [Color.fromARGB(127, 208, 208, 208), Color.fromARGB(127, 188, 99, 121), Color.fromARGB(127, 86, 101, 182), Color.fromARGB(127, 126, 190, 236)]),
+                        gradient: LinearGradient(colors: [
+                          Color.fromARGB(127, 208, 208, 208),
+                          Color.fromARGB(127, 188, 99, 121),
+                          Color.fromARGB(127, 86, 101, 182),
+                          Color.fromARGB(127, 126, 190, 236)
+                        ]),
                         width: 2,
                       ),
                       shape: BoxShape.rectangle,
@@ -258,7 +265,11 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                             onPressed: () => _tabChange(0),
                             child: Padding(
                               padding: const EdgeInsets.only(top: 20, bottom: 20),
-                              child: Text('Memories', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 0 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Memories',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                      color: _controller!.index == 0 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -270,7 +281,11 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                                 top: 20,
                                 bottom: 20,
                               ),
-                              child: Text('Capture', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 1 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Capture',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                      color: _controller!.index == 1 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -279,7 +294,11 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                             onPressed: () => _tabChange(2),
                             child: Padding(
                               padding: const EdgeInsets.only(top: 20, bottom: 20),
-                              child: Text('Chat', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 2 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Chat',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                      color: _controller!.index == 2 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -359,7 +378,8 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                   var language = SharedPreferencesUtil().recordingsLanguage;
                   var useFriendApiKeys = SharedPreferencesUtil().useFriendApiKeys;
                   Navigator.of(context).push(MaterialPageRoute(builder: (c) => const SettingsPage()));
-                  if (language != SharedPreferencesUtil().recordingsLanguage || useFriendApiKeys != SharedPreferencesUtil().useFriendApiKeys) {
+                  if (language != SharedPreferencesUtil().recordingsLanguage ||
+                      useFriendApiKeys != SharedPreferencesUtil().useFriendApiKeys) {
                     capturePageKey.currentState?.resetState();
                   }
                 },

--- a/apps/AppWithWearable/lib/pages/home/page.dart
+++ b/apps/AppWithWearable/lib/pages/home/page.dart
@@ -97,7 +97,12 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
 
   @override
   void initState() {
-    _controller = TabController(length: 3, vsync: this, initialIndex: 1);
+    _controller = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: SharedPreferencesUtil().pageToShowFromNotification,
+    );
+    SharedPreferencesUtil().pageToShowFromNotification = 1;
     SharedPreferencesUtil().onboardingCompleted = true;
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
@@ -142,8 +147,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
           });
           InstabugLog.logInfo('Friend Device Disconnected');
           if (SharedPreferencesUtil().reconnectNotificationIsChecked) {
-            createNotification(
-                title: 'Friend Device Disconnected', body: 'Please reconnect to continue using your Friend.');
+            createNotification(title: 'Friend Device Disconnected', body: 'Please reconnect to continue using your Friend.');
           }
           MixpanelManager().deviceDisconnected();
           foregroundUtil.stopForegroundTask();
@@ -240,12 +244,8 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                       color: Colors.black,
                       borderRadius: BorderRadius.all(Radius.circular(16)),
                       border: GradientBoxBorder(
-                        gradient: LinearGradient(colors: [
-                          Color.fromARGB(127, 208, 208, 208),
-                          Color.fromARGB(127, 188, 99, 121),
-                          Color.fromARGB(127, 86, 101, 182),
-                          Color.fromARGB(127, 126, 190, 236)
-                        ]),
+                        gradient:
+                            LinearGradient(colors: [Color.fromARGB(127, 208, 208, 208), Color.fromARGB(127, 188, 99, 121), Color.fromARGB(127, 86, 101, 182), Color.fromARGB(127, 126, 190, 236)]),
                         width: 2,
                       ),
                       shape: BoxShape.rectangle,
@@ -258,11 +258,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                             onPressed: () => _tabChange(0),
                             child: Padding(
                               padding: const EdgeInsets.only(top: 20, bottom: 20),
-                              child: Text('Memories',
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                      color: _controller!.index == 0 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Memories', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 0 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -274,11 +270,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                                 top: 20,
                                 bottom: 20,
                               ),
-                              child: Text('Capture',
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                      color: _controller!.index == 1 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Capture', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 1 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -287,11 +279,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                             onPressed: () => _tabChange(2),
                             child: Padding(
                               padding: const EdgeInsets.only(top: 20, bottom: 20),
-                              child: Text('Chat',
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                      color: _controller!.index == 2 ? Colors.white : Colors.grey, fontSize: 16)),
+                              child: Text('Chat', maxLines: 1, overflow: TextOverflow.ellipsis, style: TextStyle(color: _controller!.index == 2 ? Colors.white : Colors.grey, fontSize: 16)),
                             ),
                           ),
                         ),
@@ -371,8 +359,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
                   var language = SharedPreferencesUtil().recordingsLanguage;
                   var useFriendApiKeys = SharedPreferencesUtil().useFriendApiKeys;
                   Navigator.of(context).push(MaterialPageRoute(builder: (c) => const SettingsPage()));
-                  if (language != SharedPreferencesUtil().recordingsLanguage ||
-                      useFriendApiKeys != SharedPreferencesUtil().useFriendApiKeys) {
+                  if (language != SharedPreferencesUtil().recordingsLanguage || useFriendApiKeys != SharedPreferencesUtil().useFriendApiKeys) {
                     capturePageKey.currentState?.resetState();
                   }
                 },

--- a/apps/AppWithWearable/lib/pages/home/page.dart
+++ b/apps/AppWithWearable/lib/pages/home/page.dart
@@ -13,6 +13,7 @@ import 'package:friend_private/backend/database/message_provider.dart';
 import 'package:friend_private/backend/mixpanel.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
+import 'package:friend_private/main.dart';
 import 'package:friend_private/pages/capture/page.dart';
 import 'package:friend_private/pages/chat/page.dart';
 import 'package:friend_private/pages/home/device.dart';
@@ -27,6 +28,7 @@ import 'package:friend_private/utils/sentry_log.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:upgrader/upgrader.dart';
 
 class HomePageWrapper extends StatefulWidget {
@@ -95,6 +97,11 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
     _initiateMemories();
   }
 
+  ///Screens with respect to subpage
+  final Map<String, Widget> screensWithRespectToPath = {
+    '/settings': const SettingsPage(),
+  };
+
   @override
   void initState() {
     _controller = TabController(
@@ -133,7 +140,17 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
       isDailySummaryNotification: true,
       payload: {'path': '/chat'},
     );
-
+    if (SharedPreferencesUtil().subPageToShowFromNotification != '') {
+      final subPageRoute = SharedPreferencesUtil().subPageToShowFromNotification;
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        MyApp.navigatorKey.currentState?.push(
+          MaterialPageRoute(
+            builder: (context) => screensWithRespectToPath[subPageRoute] as Widget,
+          ),
+        );
+      });
+      SharedPreferencesUtil().subPageToShowFromNotification = '';
+    }
     super.initState();
   }
 

--- a/apps/AppWithWearable/lib/pages/home/page.dart
+++ b/apps/AppWithWearable/lib/pages/home/page.dart
@@ -207,7 +207,6 @@ class _HomePageWrapperState extends State<HomePageWrapper> with WidgetsBindingOb
           onTap: () {
             FocusScope.of(context).unfocus();
             chatTextFieldFocusNode.unfocus();
-
             memoriesTextFieldFocusNode.unfocus();
           },
           child: Stack(

--- a/apps/AppWithWearable/lib/utils/notifications.dart
+++ b/apps/AppWithWearable/lib/utils/notifications.dart
@@ -29,7 +29,9 @@ Future<void> initializeNotifications() async {
             ledColor: Colors.white)
       ],
       // Channel groups are only visual and are not required
-      channelGroups: [NotificationChannelGroup(channelGroupKey: 'channel_group_key', channelGroupName: 'Friend Notifications')],
+      channelGroups: [
+        NotificationChannelGroup(channelGroupKey: 'channel_group_key', channelGroupName: 'Friend Notifications')
+      ],
       debug: false);
   debugPrint('initializeNotifications: $initialized');
   NotifyOnKill.register();
@@ -137,7 +139,8 @@ class NotificationUtil {
     if (receivePort != null) {
       await onActionReceivedMethodImpl(receivedAction);
     } else {
-      print('onActionReceivedMethod was called inside a parallel dart isolate, where receivePort was never initialized.');
+      print(
+          'onActionReceivedMethod was called inside a parallel dart isolate, where receivePort was never initialized.');
       SendPort? sendPort = IsolateNameServer.lookupPortByName('notification_action_port');
 
       if (sendPort != null) {

--- a/apps/AppWithWearable/lib/utils/notifications.dart
+++ b/apps/AppWithWearable/lib/utils/notifications.dart
@@ -164,6 +164,9 @@ class NotificationUtil {
     // Always ensure that all plugins was initialized
     WidgetsFlutterBinding.ensureInitialized();
     final payload = receivedAction.payload;
+    if (payload?.containsKey('navigateTo') ?? false) {
+      SharedPreferencesUtil().subPageToShowFromNotification = payload?['navigateTo'] ?? '';
+    }
     SharedPreferencesUtil().pageToShowFromNotification = screensWithRespectToPath[payload?['path']] ?? 1;
     MyApp.navigatorKey.currentState?.pushReplacement(MaterialPageRoute(builder: (context) => const HomePageWrapper()));
   }


### PR DESCRIPTION
Description:

- You can send the path in the notification payload and when user receive the notification, the app will navigate according to path
Example:
```dart
createNotification(title: 'Test Notification', body: 'This is a test notification', payload: {'path': '/chat'});
```
- For more screens in the future, you  can update the `screensWithRespectToPath` variable in `notification.dart` file

Changes:

- Added Navigator key for navigation in the MyApp in main.dart
- Added a setter and getter for the screen position in SharedPreferencesUtil