### PR TITLE
Plugin rating rounding

### DIFF
--- a/apps/AppWithWearable/lib/pages/plugins/page.dart
+++ b/apps/AppWithWearable/lib/pages/plugins/page.dart
@@ -209,7 +209,7 @@ class _PluginsPageState extends State<PluginsPage> {
                           plugin.ratingAvg != null
                               ? Row(
                                   children: [
-                                    Text(plugin.ratingAvg!.toString()),
+                                    Text(plugin.ratingAvg!.toStringAsFixed(1)),
                                     const SizedBox(width: 4),
                                     const Icon(Icons.star, color: Colors.deepPurple, size: 16),
                                     const SizedBox(width: 4),

--- a/apps/AppWithWearable/lib/pages/plugins/plugin_detail.dart
+++ b/apps/AppWithWearable/lib/pages/plugins/plugin_detail.dart
@@ -53,7 +53,7 @@ class _PluginDetailPageState extends State<PluginDetailPage> {
                   widget.plugin.ratingAvg != null
                       ? Row(
                           children: [
-                            Text(widget.plugin.ratingAvg!.toString()),
+                            Text(widget.plugin.ratingAvg!.toStringAsFixed(1)),
                             const SizedBox(width: 4),
                             RatingBar.builder(
                               initialRating: widget.plugin.ratingAvg!,


### PR DESCRIPTION
Rounds the rating of plugins in plugins store and plugin page `4.11111111167 -> 4.1`

Fixes this 
![telegram-cloud-photo-size-2-5208907728267895738-y](https://github.com/BasedHardware/Friend/assets/75391868/d9abe476-c31f-4c5b-a7de-40df2d09fd17)
