### PR TITLE
Change naming convention for audio files

### DIFF
--- a/apps/AppWithWearable/lib/pages/capture/background_service.dart
+++ b/apps/AppWithWearable/lib/pages/capture/background_service.dart
@@ -57,12 +57,12 @@ void onStart(ServiceInstance service) async {
   var path = await getApplicationDocumentsDirectory();
   var files = Directory(path.path).listSync();
   for (var file in files) {
-    if (file.path.contains('recording_') && !file.path.contains('recording_0')) {
+    if (file.path.contains('mic_recording_') && !file.path.contains('mic_recording_0')) {
       debugPrint('deleting file: ${file.path}');
       file.deleteSync();
     }
   }
-  var filePath = '${path.path}/recording_$count.wav';
+  var filePath = '${path.path}/mic_recording_$count.wav';
   service.invoke("stateUpdate", {"state": 'recording'});
   await record.start(const RecordConfig(encoder: AudioEncoder.wav), path: filePath);
   // timerUpdate is only invoked on Android
@@ -79,7 +79,7 @@ void onStart(ServiceInstance service) async {
       var paths = SharedPreferencesUtil().recordingPaths;
       SharedPreferencesUtil().recordingPaths = [...paths, filePath];
       count++;
-      filePath = '${path.path}/recording_$count.wav';
+      filePath = '${path.path}/mic_recording_$count.wav';
       record = AudioRecorder();
       await record.start(const RecordConfig(encoder: AudioEncoder.wav), path: filePath);
       debugPrint("recording started again file: $filePath");
@@ -97,7 +97,7 @@ Future streamRecording(ServiceInstance service) async {
   var record = AudioRecorder();
   var path = await getApplicationDocumentsDirectory();
   int count = 0;
-  var filePath = '${path.path}/recording_$count.m4a';
+  var filePath = '${path.path}/mic_recording_$count.m4a';
   service.invoke("stateUpdate", {"state": 'recording'});
   var stream = await record.startStream(const RecordConfig(encoder: AudioEncoder.pcm16bits));
   var audioData = <int>[];

--- a/apps/AppWithWearable/lib/pages/capture/microphone_transcribing_util.dart
+++ b/apps/AppWithWearable/lib/pages/capture/microphone_transcribing_util.dart
@@ -15,7 +15,7 @@ Future transcribeAfterStopiOS({
   required List<TranscriptSegment> segments,
 }) async {
   var path = await getApplicationDocumentsDirectory();
-  var initalFile = File('${path.path}/recording_0.wav');
+  var initalFile = File('${path.path}/mic_recording_0.wav');
   if (initalFile.existsSync()) {
     // emptying the file instead of deleting incase if the user presses on start recording again after stopping
     initalFile.writeAsBytesSync([]);
@@ -24,7 +24,7 @@ Future transcribeAfterStopiOS({
   var files = path.listSync();
   for (var file in files) {
     if (file is File) {
-      if (!file.path.contains('recording_0')) {
+      if (!file.path.contains('mic_recording_0') && file.path.contains('mic_recording_')) {
         filePaths.add(file.path);
       }
     }
@@ -72,7 +72,7 @@ Future transcribeAfterStopAndroid(
   var files = path.listSync();
   for (var file in files) {
     if (file is File) {
-      if (file.path.contains('recording_')) {
+      if (file.path.contains('mic_recording_')) {
         if (!SharedPreferencesUtil().recordingPaths.contains(file.path)) {
           filePaths.add(file.path);
         }
@@ -118,13 +118,15 @@ Future iosBgCallback({
   required int partNumber,
   required Function processFileToTranscript,
   required Function(int) updateState,
+  required Function updateTimer,
 }) async {
   try {
     var path = await getApplicationDocumentsDirectory();
-    var filePath = '${path.path}/recording_0.wav';
+    var filePath = '${path.path}/mic_recording_0.wav';
     final file = File(filePath);
 
     if (await file.exists()) {
+      updateTimer();
       // Get the current length of the file
       final currentLength = await file.length();
       debugPrint('Current length: $currentLength and last offset: $lastOffset');
@@ -137,7 +139,7 @@ Future iosBgCallback({
 
         // Write the new content to a new file
         var path = await getApplicationDocumentsDirectory();
-        final newFilePath = '${path.path}/recording_$partNumber.wav';
+        final newFilePath = '${path.path}/mic_recording_$partNumber.wav';
         final newFile = File(newFilePath);
         var header = WavBytesUtil.getWavHeader(newContent.length, 44100, channelCount: 2);
         newContent = [...header, ...newContent];
@@ -169,7 +171,7 @@ Future androidBgCallback({
   required Function processFileToTranscript,
 }) async {
   var path = await getApplicationDocumentsDirectory();
-  var filePath = '${path.path}/recording_$fileCount.wav';
+  var filePath = '${path.path}/mic_recording_$fileCount.wav';
   var file = File(filePath);
   backgroundService.invoke('timerUpdate', {'time': '0'});
   if (file.existsSync()) {

--- a/apps/AppWithWearable/lib/pages/capture/phone_recorder_mixin.dart
+++ b/apps/AppWithWearable/lib/pages/capture/phone_recorder_mixin.dart
@@ -94,8 +94,13 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
           setState(() {
             lastOffset = currentLength;
             partNumber++;
-            iosDuration = 5;
+
             isTranscribing = false;
+          });
+        },
+        updateTimer: () {
+          setState(() {
+            iosDuration = 5;
           });
         },
       );
@@ -209,7 +214,7 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
     backgroundTranscriptTimer = Timer.periodic(interval, (timer) async {
       debugPrint('timer triggered at ${DateTime.now()}');
       var path = await getApplicationDocumentsDirectory();
-      var filePath = '${path.path}/recording_0.wav';
+      var filePath = '${path.path}/mic_recording_0.wav';
       try {
         debugPrint('isTranscribing: $isTranscribing');
         if (isTranscribing) return;
@@ -222,8 +227,12 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
             setState(() {
               lastOffset = currentLength;
               partNumber++;
-              iosDuration = 30;
               isTranscribing = false;
+            });
+          },
+          updateTimer: () {
+            setState(() {
+              iosDuration = 30;
             });
           },
         );


### PR DESCRIPTION
This PR changes the naming convention from `recording_${number}` to `mic_recording_${number}` for microphone recorded audio files. This is being done to avoid transcribing audio files that have been generated through the device.