### PR TITLE
Fix non-english characters rendering

### DIFF
--- a/apps/AppWithWearable/lib/backend/database/transcript_segment.dart
+++ b/apps/AppWithWearable/lib/backend/database/transcript_segment.dart
@@ -144,7 +144,7 @@ class TranscriptSegment {
     includeTimestamps = includeTimestamps && TranscriptSegment.canDisplaySeconds(segments);
     for (var segment in segments) {
       // TODO: maybe store TranscriptSegment directly as utf8 decoded
-      var segmentText = utf8.decode(segment.text.trim().codeUnits);
+      var segmentText = String.fromCharCodes(segment.text.trim().codeUnits);
       var timestampStr = includeTimestamps ? '[${segment.getTimestampString()}]' : '';
       if (segment.isUser) {
         transcript += '$timestampStr ${userName.isEmpty ? 'User' : userName}: $segmentText ';

--- a/apps/AppWithWearable/lib/pages/plugins/plugin_detail.dart
+++ b/apps/AppWithWearable/lib/pages/plugins/plugin_detail.dart
@@ -147,7 +147,7 @@ class _PluginDetailPageState extends State<PluginDetailPage> {
                 ? Padding(
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     child: Text(
-                      utf8.decode((widget.plugin.memoryPrompt ?? '').codeUnits),
+                      String.fromCharCodes((widget.plugin.memoryPrompt ?? '').codeUnits),
                       style: const TextStyle(color: Colors.grey, fontSize: 15, height: 1.4),
                     ),
                   )

--- a/apps/AppWithWearable/lib/widgets/transcript.dart
+++ b/apps/AppWithWearable/lib/widgets/transcript.dart
@@ -73,7 +73,7 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
                 alignment: Alignment.centerLeft,
                 child: SelectionArea(
                   child: Text(
-                    utf8.decode(data.text.toString().codeUnits, allowMalformed: true),
+                    String.fromCharCodes(data.text.toString().codeUnits),
                     style: const TextStyle(letterSpacing: 0.0, color: Colors.grey),
                     textAlign: TextAlign.left,
                   ),


### PR DESCRIPTION
Should close #480 and #434 
Some characters in other languages get rendered as `???` in the App. It happens because the [String.codeUnits](https://api.flutter.dev/flutter/dart-core/String/codeUnits.html) method in Dart returns a list of UTF-16 code units, which are 16-bit values representing the characters in the string. When the codeUnits are passed to utf8.decode, the decode method will end up truncating the characters incorrectly, especially for characters outside the Basic Multilingual Plane (BMP) that are represented by surrogate pairs in UTF-16. The decode method may work for words where all the codePoints are small enough to not be truncated.

Before (Spanish)           |  After (Spanish)
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/95da5566-6f9b-4dc9-b9af-b5ea456e49f4)  |  ![after](https://github.com/user-attachments/assets/918ba7be-9c85-4d6e-b8c2-aaa0c3c096a5)

Before (Hindi)           |  After (Hindi)
:-------------------------:|:-------------------------:
![before](https://github.com/user-attachments/assets/84ed4d65-1871-4450-a8a4-e0c31de7d33a)  |  ![after](https://github.com/user-attachments/assets/a5a4a3eb-d9f8-40f9-a03a-3e3ce4a5cf4b)