### PR TITLE
Connect app with Frame by Brilliant Labs

### DIFF
--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -157,6 +157,12 @@ class CapturePageState extends State<CapturePage>
     closeWebSocket();
   }
 
+  Future<void> startBrilliantLabsFrame() async {
+    if (btDevice == null) return;
+    await brilliantLabsFrameProcessing(btDevice!, (p) => setState(() {}), setHasTranscripts);
+    closeWebSocket();
+  }
+
   void resetState({bool restartBytesProcessing = true, BTDeviceStruct? btDevice}) {
     debugPrint('resetState: $restartBytesProcessing');
     _bleBytesStream?.cancel();
@@ -165,6 +171,7 @@ class CapturePageState extends State<CapturePage>
     if (btDevice != null) setState(() => this.btDevice = btDevice);
     if (restartBytesProcessing) {
       startOpenGlass();
+      startBrilliantLabsFrame();
       initiateFriendAudioStreaming();
     }
   }
@@ -277,6 +284,7 @@ class CapturePageState extends State<CapturePage>
     WavBytesUtil.clearTempWavFiles();
     initiateWebsocket();
     startOpenGlass();
+    startBrilliantLabsFrame();
     initiateFriendAudioStreaming();
     processCachedTranscript();
 

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -6,6 +6,7 @@ import 'package:friend_private/utils/ble/connect.dart';
 import 'package:friend_private/utils/ble/gatt_utils.dart';
 import 'package:friend_private/widgets/device_widget.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:friend_private/utils/ble/communication.dart'; // Import the communication file
 
 class ConnectedDevice extends StatefulWidget {
   // TODO: retrieve this from here instead of params
@@ -72,9 +73,21 @@ class _DeviceInfo {
 }
 
 class _ConnectedDeviceState extends State<ConnectedDevice> {
+  int brilliantLabsFrameBatteryLevel = -1; // Initialize the battery level
+
   @override
   void initState() {
     super.initState();
+    if (widget.device != null) {
+      _retrieveBrilliantLabsFrameBatteryLevel(widget.device!.id);
+    }
+  }
+
+  Future<void> _retrieveBrilliantLabsFrameBatteryLevel(String deviceId) async {
+    int batteryLevel = await retrieveBrilliantLabsFrameBatteryLevel(deviceId);
+    setState(() {
+      brilliantLabsFrameBatteryLevel = batteryLevel;
+    });
   }
 
   @override
@@ -170,7 +183,40 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                               ),
                             ],
                           ))
-                      : const SizedBox.shrink()
+                      : const SizedBox.shrink(),
+                  if (brilliantLabsFrameBatteryLevel != -1)
+                    Container(
+                      decoration: BoxDecoration(
+                        color: Colors.transparent,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 10,
+                            height: 10,
+                            decoration: BoxDecoration(
+                              color: brilliantLabsFrameBatteryLevel > 75
+                                  ? const Color.fromARGB(255, 0, 255, 8)
+                                  : brilliantLabsFrameBatteryLevel > 20
+                                      ? Colors.yellow.shade700
+                                      : Colors.red,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                          const SizedBox(width: 8.0),
+                          Text(
+                            '${brilliantLabsFrameBatteryLevel.toString()}% Frame Battery',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                 ],
               ),
               const SizedBox(height: 32),

--- a/app/lib/utils/websockets.dart
+++ b/app/lib/utils/websockets.dart
@@ -106,3 +106,37 @@ Future<IOWebSocketChannel?> streamingTranscript({
 
   return null;
 }
+
+Future<void> handleBrilliantLabsFrameStream({
+  required void Function(List<TranscriptSegment>) onMessageReceived,
+  required void Function(List<int>) onAudioBytesReceived,
+  required void Function(List<int>) onImageBytesReceived,
+  required VoidCallback onWebsocketConnectionSuccess,
+  required void Function(dynamic) onWebsocketConnectionFailed,
+  required void Function(int?, String?) onWebsocketConnectionClosed,
+  required void Function(dynamic) onWebsocketConnectionError,
+  required BleAudioCodec codec,
+  required int sampleRate,
+}) async {
+  IOWebSocketChannel? channel = await streamingTranscript(
+    onWebsocketConnectionSuccess: onWebsocketConnectionSuccess,
+    onWebsocketConnectionFailed: onWebsocketConnectionFailed,
+    onWebsocketConnectionClosed: onWebsocketConnectionClosed,
+    onWebsocketConnectionError: onWebsocketConnectionError,
+    onMessageReceived: onMessageReceived,
+    codec: codec,
+    sampleRate: sampleRate,
+  );
+
+  if (channel != null) {
+    await getBleAudioBytesListener(
+      'brilliant_labs_frame_device_id',
+      onAudioBytesReceived: onAudioBytesReceived,
+    );
+
+    await getBleImageBytesListener(
+      'brilliant_labs_frame_device_id',
+      onImageBytesReceived: onImageBytesReceived,
+    );
+  }
+}


### PR DESCRIPTION
Related to #532

Add support for connecting to Brilliant Labs Frame and streaming photos and audio.

* **app/lib/utils/ble/communication.dart**
  - Add methods to connect to the BLE characteristic of Brilliant Labs Frame, start streaming photos and audio, and retrieve the battery level.
* **app/lib/pages/capture/logic/openglass_mixin.dart**
  - Add logic to handle photo and audio streaming from Brilliant Labs Frame.
* **app/lib/pages/home/device.dart**
  - Add logic to display the battery level of Brilliant Labs Frame.
* **app/lib/pages/capture/page.dart**
  - Add logic to initiate the connection to Brilliant Labs Frame and handle the streaming of photos and audio.
* **app/lib/utils/websockets.dart**
  - Add logic to handle the streaming of photos and audio from Brilliant Labs Frame.