### PR TITLE
Add Google Drive export plugin

### DIFF
--- a/app/lib/backend/http/cloud_storage.dart
+++ b/app/lib/backend/http/cloud_storage.dart
@@ -5,8 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;
+import 'package:googleapis/drive/v3.dart' as drive;
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:googleapis/drive/v3.dart' as drive;
+import 'package:googleapis_auth/auth_io.dart';
 
 AuthClient? authClient;
+drive.DriveApi? driveApi;
 
 Future<void> authenticateGCP({String? base64}) async {
   var credentialsBase64 = base64 ?? SharedPreferencesUtil().gcpCredentials;
@@ -20,6 +26,19 @@ Future<void> authenticateGCP({String? base64}) async {
   var scopes = ['https://www.googleapis.com/auth/devstorage.full_control'];
   authClient = await clientViaServiceAccount(credentials, scopes);
   debugPrint('Authenticated');
+}
+
+Future<void> authenticateGoogleDrive() async {
+  final googleSignIn = GoogleSignIn.standard(scopes: [drive.DriveApi.driveFileScope]);
+  final account = await googleSignIn.signIn();
+  if (account == null) {
+    debugPrint('Google sign-in failed');
+    return;
+  }
+  final authHeaders = await account.authHeaders;
+  final authenticateClient = GoogleAuthClient(authHeaders);
+  driveApi = drive.DriveApi(authenticateClient);
+  debugPrint('Google Drive authenticated');
 }
 
 Future<String?> uploadFile(File file, {bool prefixTimestamp = false}) async {
@@ -58,6 +77,28 @@ Future<String?> uploadFile(File file, {bool prefixTimestamp = false}) async {
   return null;
 }
 
+Future<String?> uploadFileToGoogleDrive(File file, String folderId) async {
+  if (driveApi == null) {
+    debugPrint('Google Drive API is not authenticated');
+    return null;
+  }
+
+  String fileName = file.path.split('/').last;
+  var media = drive.Media(file.openRead(), file.lengthSync());
+  var driveFile = drive.File()
+    ..name = fileName
+    ..parents = [folderId];
+
+  try {
+    var response = await driveApi!.files.create(driveFile, uploadMedia: media);
+    debugPrint('Upload to Google Drive successful: ${response.id}');
+    return response.id;
+  } catch (e) {
+    debugPrint('Error uploading file to Google Drive: $e');
+  }
+  return null;
+}
+
 // Download file method
 // Future<File?> downloadFile(String objectName, String saveFileName) async {
 //   final directory = await getApplicationDocumentsDirectory();
@@ -92,3 +133,15 @@ Future<String?> uploadFile(File file, {bool prefixTimestamp = false}) async {
 //   }
 //   return null;
 // }
+
+class GoogleAuthClient extends http.BaseClient {
+  final Map<String, String> _headers;
+  final http.Client _client = http.Client();
+
+  GoogleAuthClient(this._headers);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return _client.send(request..headers.addAll(_headers));
+  }
+}

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -286,4 +286,18 @@ class SharedPreferencesUtil {
   set locationPermissionRequested(bool value) => saveBool('locationPermissionRequested', value);
 
   bool get locationPermissionRequested => getBool('locationPermissionRequested') ?? false;
+
+  // Google Drive Export Preferences
+
+  bool get googleDriveExportEnabled => getBool('googleDriveExportEnabled') ?? false;
+
+  set googleDriveExportEnabled(bool value) => saveBool('googleDriveExportEnabled', value);
+
+  String get googleDriveFolderId => getString('googleDriveFolderId') ?? '';
+
+  set googleDriveFolderId(String value) => saveString('googleDriveFolderId', value);
+
+  List<String> get googleDriveExportParts => getStringList('googleDriveExportParts') ?? [];
+
+  set googleDriveExportParts(List<String> value) => saveStringList('googleDriveExportParts', value);
 }

--- a/app/lib/pages/settings/page.dart
+++ b/app/lib/pages/settings/page.dart
@@ -25,6 +25,9 @@ class _SettingsPageState extends State<SettingsPage> {
   late bool devModeEnabled;
   late bool postMemoryNotificationIsChecked;
   late bool reconnectNotificationIsChecked;
+  late bool googleDriveExportEnabled;
+  late String googleDriveFolderId;
+  late List<String> googleDriveExportParts;
   String? version;
   String? buildVersion;
 
@@ -35,6 +38,9 @@ class _SettingsPageState extends State<SettingsPage> {
     devModeEnabled = SharedPreferencesUtil().devModeEnabled;
     postMemoryNotificationIsChecked = SharedPreferencesUtil().postMemoryNotificationIsChecked;
     reconnectNotificationIsChecked = SharedPreferencesUtil().reconnectNotificationIsChecked;
+    googleDriveExportEnabled = SharedPreferencesUtil().googleDriveExportEnabled;
+    googleDriveFolderId = SharedPreferencesUtil().googleDriveFolderId;
+    googleDriveExportParts = SharedPreferencesUtil().googleDriveExportParts;
     PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
       version = packageInfo.version;
       buildVersion = packageInfo.buildNumber.toString();
@@ -92,6 +98,83 @@ class _SettingsPageState extends State<SettingsPage> {
                     SharedPreferencesUtil().recordingsLanguage = _selectedLanguage;
                     MixpanelManager().recordingLanguageChanged(_selectedLanguage);
                   }, _selectedLanguage),
+                  const SizedBox(height: 32.0),
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'GOOGLE DRIVE EXPORT',
+                      style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SwitchListTile(
+                    title: const Text('Enable Google Drive Export', style: TextStyle(color: Colors.white)),
+                    value: googleDriveExportEnabled,
+                    onChanged: (bool value) {
+                      setState(() {
+                        googleDriveExportEnabled = value;
+                        SharedPreferencesUtil().googleDriveExportEnabled = value;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    decoration: const InputDecoration(
+                      labelText: 'Google Drive Folder ID',
+                      labelStyle: TextStyle(color: Colors.white),
+                      enabledBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
+                      ),
+                      focusedBorder: UnderlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
+                      ),
+                    ),
+                    style: const TextStyle(color: Colors.white),
+                    onChanged: (value) {
+                      setState(() {
+                        googleDriveFolderId = value;
+                        SharedPreferencesUtil().googleDriveFolderId = value;
+                      });
+                    },
+                    controller: TextEditingController(text: googleDriveFolderId),
+                  ),
+                  const SizedBox(height: 12),
+                  const Align(
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      'Select parts to export:',
+                      style: TextStyle(color: Colors.white, fontSize: 16),
+                    ),
+                  ),
+                  CheckboxListTile(
+                    title: const Text('Transcript', style: TextStyle(color: Colors.white)),
+                    value: googleDriveExportParts.contains('transcript'),
+                    onChanged: (bool? value) {
+                      setState(() {
+                        if (value == true) {
+                          googleDriveExportParts.add('transcript');
+                        } else {
+                          googleDriveExportParts.remove('transcript');
+                        }
+                        SharedPreferencesUtil().googleDriveExportParts = googleDriveExportParts;
+                      });
+                    },
+                  ),
+                  CheckboxListTile(
+                    title: const Text('Raw Audio', style: TextStyle(color: Colors.white)),
+                    value: googleDriveExportParts.contains('raw_audio'),
+                    onChanged: (bool? value) {
+                      setState(() {
+                        if (value == true) {
+                          googleDriveExportParts.add('raw_audio');
+                        } else {
+                          googleDriveExportParts.remove('raw_audio');
+                        }
+                        SharedPreferencesUtil().googleDriveExportParts = googleDriveExportParts;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
                   ...getPreferencesWidgets(
                     onOptInAnalytics: () {
                       setState(() {

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -15,3 +15,16 @@ DEEPGRAM_API_KEY=
 
 ADMIN_KEY=
 OPENAI_API_KEY=
+
+# Google Drive API credentials
+GOOGLE_DRIVE_CLIENT_ID=
+GOOGLE_DRIVE_CLIENT_SECRET=
+GOOGLE_DRIVE_REDIRECT_URI=
+
+# Instructions for obtaining Google Drive API credentials:
+# 1. Go to the Google Cloud Console: https://console.cloud.google.com/
+# 2. Create a new project or select an existing project.
+# 3. Enable the Google Drive API for the project.
+# 4. Create OAuth 2.0 credentials (Client ID and Client Secret) for the project.
+# 5. Set the redirect URI to your application's redirect URI.
+# 6. Copy the Client ID, Client Secret, and Redirect URI to the corresponding environment variables above.

--- a/plugins/google_drive_export/memory_created.py
+++ b/plugins/google_drive_export/memory_created.py
@@ -1,0 +1,56 @@
+import os
+import requests
+from fastapi import APIRouter, HTTPException, Request, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+from models import Memory, EndpointResponse
+
+router = APIRouter()
+templates = Jinja2Templates(directory="templates")
+
+SCOPES = ['https://www.googleapis.com/auth/drive.file']
+SERVICE_ACCOUNT_FILE = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+
+credentials = service_account.Credentials.from_service_account_file(
+    SERVICE_ACCOUNT_FILE, scopes=SCOPES)
+drive_service = build('drive', 'v3', credentials=credentials)
+
+
+@router.get('/setup-google-drive', response_class=HTMLResponse, tags=['google_drive_export'])
+async def setup_google_drive(request: Request, uid: str):
+    if not uid:
+        raise HTTPException(status_code=400, detail='UID is required')
+    return templates.TemplateResponse("setup_google_drive.html", {"request": request, "uid": uid})
+
+
+@router.post('/creds/google-drive', response_class=HTMLResponse, tags=['google_drive_export'])
+def creds_google_drive(request: Request, uid: str = Form(...), folder_id: str = Form(...)):
+    if not folder_id:
+        raise HTTPException(status_code=400, detail='Folder ID is required')
+    store_google_drive_folder_id(uid, folder_id)
+    return templates.TemplateResponse("okpage.html", {"request": request, "uid": uid})
+
+
+@router.get('/setup/google-drive', tags=['google_drive_export'])
+def is_setup_completed(uid: str):
+    folder_id = get_google_drive_folder_id(uid)
+    return {'is_setup_completed': folder_id is not None}
+
+
+@router.post('/google-drive', tags=['google_drive_export', 'memory_created'], response_model=EndpointResponse)
+def google_drive_export(memory: Memory, uid: str):
+    folder_id = get_google_drive_folder_id(uid)
+    if not folder_id:
+        return {'message': 'Your Google Drive plugin is not setup properly. Check your plugin settings.'}
+
+    file_metadata = {
+        'name': f'{memory.structured.title}.txt',
+        'parents': [folder_id]
+    }
+    media = MediaFileUpload(memory.get_transcript(), mimetype='text/plain')
+    file = drive_service.files().create(body=file_metadata, media_body=media, fields='id').execute()
+    return {'message': f'File ID: {file.get("id")}'}


### PR DESCRIPTION
Related to #494

Add Google Drive export plugin and settings.

* **New Plugin**: Add `plugins/google_drive_export/memory_created.py` to implement Google Drive export functionality using Google Drive API.
* **Backend Changes**: Update `app/lib/backend/http/cloud_storage.dart` to include functions for authenticating and uploading files to Google Drive.
* **Preferences**: Modify `app/lib/backend/preferences.dart` to add preferences for Google Drive export settings, including enabling export, folder ID, and parts to export.
* **Settings Page**: Update `app/lib/pages/settings/page.dart` to include UI elements for configuring Google Drive export settings.
* **Environment Variables**: Update `backend/.env.template` to include environment variables for Google Drive API credentials.