### PR TITLE
Add custom server URL for sending raw audio files

### DIFF
--- a/app/lib/backend/http/webhooks.dart
+++ b/app/lib/backend/http/webhooks.dart
@@ -11,7 +11,7 @@ import 'package:instabug_flutter/instabug_flutter.dart';
 Future<String> webhookOnMemoryCreatedCall(ServerMemory? memory, {bool returnRawBody = false}) async {
   if (memory == null) return '';
   debugPrint('devModeWebhookCall: $memory');
-  String url = SharedPreferencesUtil().webhookOnMemoryCreated;
+  String url = SharedPreferencesUtil().userDefinedAudioUrl;
   if (url.isEmpty) return '';
   if (url.contains('?')) {
     url += '&uid=${SharedPreferencesUtil().uid}';
@@ -46,7 +46,7 @@ Future<String> webhookOnMemoryCreatedCall(ServerMemory? memory, {bool returnRawB
 
 Future<String> webhookOnTranscriptReceivedCall(List<TranscriptSegment> segments, String sessionId) async {
   debugPrint('webhookOnTranscriptReceivedCall: $segments');
-  return triggerTranscriptSegmentsRequest(SharedPreferencesUtil().webhookOnTranscriptReceived, sessionId, segments);
+  return triggerTranscriptSegmentsRequest(SharedPreferencesUtil().userDefinedAudioUrl, sessionId, segments);
 }
 
 
@@ -100,5 +100,27 @@ Future<String?> wavToBase64(String filePath) async {
   } catch (e) {
     // print('Error converting WAV to base64: $e');
     return null; // Handle error gracefully in your application
+  }
+}
+
+Future<void> sendRawAudioToCustomServer(File audioFile) async {
+  String customServerUrl = SharedPreferencesUtil().customServerUrl;
+  if (customServerUrl.isEmpty) {
+    debugPrint('No custom server URL defined');
+    return;
+  }
+
+  try {
+    var request = http.MultipartRequest('POST', Uri.parse(customServerUrl));
+    request.files.add(await http.MultipartFile.fromPath('file', audioFile.path));
+    var response = await request.send();
+
+    if (response.statusCode == 200) {
+      debugPrint('Audio file sent successfully to custom server');
+    } else {
+      debugPrint('Failed to send audio file to custom server: ${response.statusCode}');
+    }
+  } catch (e) {
+    debugPrint('Error sending audio file to custom server: $e');
   }
 }

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -171,6 +171,14 @@ class SharedPreferencesUtil {
 
   set lastDailySummaryDay(String value) => saveString('lastDailySummaryDate', value);
 
+  String get userDefinedAudioUrl => getString('userDefinedAudioUrl') ?? '';
+
+  set userDefinedAudioUrl(String value) => saveString('userDefinedAudioUrl', value);
+
+  String get customServerUrl => getString('customServerUrl') ?? '';
+
+  set customServerUrl(String value) => saveString('customServerUrl', value);
+
   Future<bool> saveString(String key, String value) async {
     return await _preferences?.setString(key, value) ?? false;
   }

--- a/app/lib/pages/capture/logic/phone_recorder_mixin.dart
+++ b/app/lib/pages/capture/logic/phone_recorder_mixin.dart
@@ -1,8 +1,11 @@
 import 'dart:typed_data';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/utils/websockets.dart';
+import 'package:friend_private/backend/http/webhooks.dart';
+import 'package:friend_private/backend/preferences.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
@@ -46,6 +49,13 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
     if (await record.isRecording()) await record.stop();
     if (wsConnectionState == WebsocketConnectionStatus.connected) websocketChannel?.sink.close();
     setState(() => recordingState = RecordingState.stop);
+
+    // Send raw audio file to custom server URL
+    String customServerUrl = SharedPreferencesUtil().customServerUrl;
+    if (customServerUrl.isNotEmpty) {
+      File audioFile = File(record.path);
+      await sendRawAudioToCustomServer(audioFile);
+    }
   }
 
   @override

--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -248,6 +248,16 @@ class CapturePageState extends State<CapturePage>
     photos = [];
     conversationId = const Uuid().v4();
     setState(() => memoryCreating = false);
+
+    // Send audio data to user-defined URL
+    String userDefinedAudioUrl = SharedPreferencesUtil().userDefinedAudioUrl;
+    if (userDefinedAudioUrl.isNotEmpty && file != null) {
+      try {
+        await uploadFileToUserDefinedUrl(file, userDefinedAudioUrl);
+      } catch (e) {
+        print('Error uploading file to user-defined URL: $e');
+      }
+    }
   }
 
   setHasTranscripts(bool hasTranscripts) {

--- a/app/lib/pages/settings/page.dart
+++ b/app/lib/pages/settings/page.dart
@@ -27,6 +27,8 @@ class _SettingsPageState extends State<SettingsPage> {
   late bool reconnectNotificationIsChecked;
   String? version;
   String? buildVersion;
+  late TextEditingController _audioUrlController;
+  late TextEditingController _customServerUrlController;
 
   @override
   void initState() {
@@ -35,6 +37,8 @@ class _SettingsPageState extends State<SettingsPage> {
     devModeEnabled = SharedPreferencesUtil().devModeEnabled;
     postMemoryNotificationIsChecked = SharedPreferencesUtil().postMemoryNotificationIsChecked;
     reconnectNotificationIsChecked = SharedPreferencesUtil().reconnectNotificationIsChecked;
+    _audioUrlController = TextEditingController(text: SharedPreferencesUtil().userDefinedAudioUrl);
+    _customServerUrlController = TextEditingController(text: SharedPreferencesUtil().customServerUrl);
     PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
       version = packageInfo.version;
       buildVersion = packageInfo.buildNumber.toString();
@@ -92,6 +96,43 @@ class _SettingsPageState extends State<SettingsPage> {
                     SharedPreferencesUtil().recordingsLanguage = _selectedLanguage;
                     MixpanelManager().recordingLanguageChanged(_selectedLanguage);
                   }, _selectedLanguage),
+                  const SizedBox(height: 16.0),
+                  TextField(
+                    controller: _audioUrlController,
+                    decoration: const InputDecoration(
+                      labelText: 'Audio URL',
+                      labelStyle: TextStyle(color: Colors.white),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.blue),
+                      ),
+                    ),
+                    style: const TextStyle(color: Colors.white),
+                    onChanged: (value) {
+                      SharedPreferencesUtil().userDefinedAudioUrl = value;
+                    },
+                  ),
+                  const SizedBox(height: 16.0),
+                  TextField(
+                    controller: _customServerUrlController,
+                    decoration: const InputDecoration(
+                      labelText: 'Custom Server URL',
+                      labelStyle: TextStyle(color: Colors.white),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.white),
+                      ),
+                      focusedBorder: OutlineInputBorder(
+                        borderSide: BorderSide(color: Colors.blue),
+                      ),
+                    ),
+                    style: const TextStyle(color: Colors.white),
+                    onChanged: (value) {
+                      SharedPreferencesUtil().customServerUrl = value;
+                    },
+                  ),
+                  const SizedBox(height: 32.0),
                   ...getPreferencesWidgets(
                     onOptInAnalytics: () {
                       setState(() {


### PR DESCRIPTION
Related to #478

Add functionality to send raw audio files to a custom server URL for every recording.

* **Preferences**: Add `customServerUrl` and `userDefinedAudioUrl` fields in `SharedPreferencesUtil` to store custom server URLs.
* **Webhooks**: Add `sendRawAudioToCustomServer` method in `webhooks.dart` to handle sending raw audio files to a custom server URL.
* **Settings Page**: Add input fields in the settings page to allow users to define their own URLs for sending raw audio files and custom server URLs.
* **Capture Page**: Modify `_createMemory` method to send audio data to the user-defined URL after memory creation.
* **Phone Recorder Mixin**: Modify `stopStreamRecording` method to send raw audio files to the custom server URL after stopping the recording.